### PR TITLE
Add curl as build and runtime dependency

### DIFF
--- a/pynio/meta.yaml
+++ b/pynio/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - gdal
     - libiconv
     - hdfeos5 
+    - curl
 
   run:
     - libgcc
@@ -45,6 +46,7 @@ requirements:
     - gdal
     - libiconv
     - hdfeos5
+    - curl
 
 test:
   requires:


### PR DESCRIPTION
Note: I haven't had a successful build of pynio yet, but I did notice that these two dependencies were not provided in the yaml. I don't think it'll hurt anything, and it may even fix some of the build issues on Macs?